### PR TITLE
refactor inventory title name to a constant

### DIFF
--- a/src/com/gmail/kamilkime/kinvbackup/listeners/InventoryClickListener.java
+++ b/src/com/gmail/kamilkime/kinvbackup/listeners/InventoryClickListener.java
@@ -9,13 +9,15 @@ import com.gmail.kamilkime.kinvbackup.utils.StringUtils;
 
 public class InventoryClickListener implements Listener {
 
+	private static final String INV_TITLE = StringUtils.color("&5&lKInvBackup backup display");
+
 	@EventHandler
 	public void onClick(InventoryClickEvent e){
 		if(e.getInventory() == null) return;
 		if(e.getCurrentItem() == null) return;
 		if(e.getCurrentItem().getType().equals(Material.AIR)) return;
 		if(e.getInventory().getTitle() == null) return;
-		if(e.getInventory().getTitle().equals(StringUtils.color("&5&lKInvBackup backup display"))){
+		if(e.getInventory().getTitle().equals(INV_TITLE)){
 			e.setCancelled(true);
 			e.getWhoClicked().openInventory(e.getInventory());
 		}


### PR DESCRIPTION
Since the result of `StringUtils.color("&5&lKInvBackup backup display")` never change, I think that it will run faster if it becomes a constant.
